### PR TITLE
Fix: Ensure environment isolation for certs and configs

### DIFF
--- a/aws_vpn_admin.sh
+++ b/aws_vpn_admin.sh
@@ -87,7 +87,7 @@ create_vpn_endpoint() {
     
     # 1. 生成證書 (如果不存在) - 使用環境感知路徑
     if [ ! -f "$VPN_CERT_DIR/pki/ca.crt" ]; then
-        generate_certificates_lib "$VPN_CERT_DIR"
+        generate_certificates_lib "$VPN_CERT_DIR" "$CONFIG_FILE"
         if [ $? -ne 0 ]; then
             echo -e "${RED}證書生成失敗。中止操作。${NC}"
             return 1

--- a/lib/aws_setup.sh
+++ b/lib/aws_setup.sh
@@ -94,7 +94,7 @@ EOF
         main_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # SCRIPT_DIR of the script calling this lib function
         echo "EASYRSA_DIR=/usr/local/share/easy-rsa" >> "$main_config_file"
         # 使用環境變數而不是硬編碼路徑
-        echo "CERT_OUTPUT_DIR=${VPN_CERT_DIR:-$main_script_dir/certificates}" >> "$main_config_file"
+        update_config "$main_config_file" "CERT_OUTPUT_DIR" "$VPN_CERT_DIR"
         echo "SERVER_CERT_NAME_PREFIX=server" >> "$main_config_file"
         echo "CLIENT_CERT_NAME_PREFIX=client" >> "$main_config_file"
         log_message_core "AWS 配置已更新，區域: ${aws_region} 及其他預設配置。"

--- a/revoke_member_access.sh
+++ b/revoke_member_access.sh
@@ -403,7 +403,7 @@ revoke_certificates() {
                     echo -e "${BLUE}找到證書名稱: $cert_name${NC}"
                     
                     # 執行本地 easyrsa 撤銷
-                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$cert_name"; then
+                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$cert_name" "$CONFIG_FILE"; then
                         echo -e "${GREEN}✓ 本地撤銷成功: $cert_name${NC}"
                         easyrsa_revoked+=("$cert_name")
                     else
@@ -414,7 +414,7 @@ revoke_certificates() {
                     echo -e "${YELLOW}無法從證書標籤中獲取用戶名，嘗試使用參數用戶名: $username${NC}"
                     
                     # 使用腳本參數中的用戶名嘗試撤銷
-                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$username"; then
+                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$username" "$CONFIG_FILE"; then
                         echo -e "${GREEN}✓ 本地撤銷成功 (使用用戶名): $username${NC}"
                         easyrsa_revoked+=("$username")
                     else

--- a/team_member_setup.sh
+++ b/team_member_setup.sh
@@ -394,8 +394,6 @@ generate_client_certificate() {
     # 優先檢查環境特定的 CA 證書路徑
     if [ -f "$VPN_CA_CERT_FILE" ]; then
         ca_cert_path="$VPN_CA_CERT_FILE"
-    elif [ -f "$SCRIPT_DIR/ca.crt" ]; then
-        ca_cert_path="$SCRIPT_DIR/ca.crt"
     elif [ -f "$VPN_CERT_DIR/ca.crt" ]; then
         ca_cert_path="$VPN_CERT_DIR/ca.crt"
     else


### PR DESCRIPTION
This commit addresses critical issues related to hardcoded paths and global configuration files, ensuring proper environment isolation for VPN setups.

Key changes:

1.  `lib/cert_management.sh`:
    - Certificate generation functions (`generate_ca_certificate_lib`, `generate_server_certificate_lib`, `generate_client_certificate_lib`) now accept an `env_config_file` parameter. ARNs are written to this environment-specific file using `update_config` instead of the global `lib/vpn_config`.
    - `revoke_client_certificate_lib` now accepts `env_config_file` and sources the `ENDPOINT_ID` from it, crucial for correct CRL updates.
    - `generate_certificates_lib` was updated to pass `env_config_file` to the individual cert generation functions.

2.  `lib/aws_setup.sh`:
    - `setup_aws_config_lib` now writes `CERT_OUTPUT_DIR` using `update_config` with the environment-specific `$VPN_CERT_DIR`, removing a fallback to a global path.

3.  `team_member_setup.sh`:
    - Removed a fallback in `generate_client_certificate` that could lead to using a global CA certificate (`$SCRIPT_DIR/ca.crt`). The script now strictly uses environment-specific CA paths.

4.  Caller Script Updates:
    - `aws_vpn_admin.sh`: Updated to pass the environment-specific config file to `generate_certificates_lib`.
    - `revoke_member_access.sh`: Updated to pass the environment-specific config file to `revoke_client_certificate_lib`.

These changes ensure that certificate paths, ARN storage, configuration variables (like `ENDPOINT_ID` for CRLs), and output directories are all correctly scoped to the active environment defined by `env_manager.sh`. This resolves issues where staging and production environments could previously share certificate authorities, server certificates, or configurations, and ensures the revocation process targets the correct VPN endpoint.