### PR TITLE
Refactor: Move admin scripts to admin/ subdirectory

### DIFF
--- a/admin/aws_vpn_admin.sh
+++ b/admin/aws_vpn_admin.sh
@@ -9,7 +9,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 載入環境管理器 (必須第一個載入)
-source "$SCRIPT_DIR/lib/env_manager.sh"
+source "$SCRIPT_DIR/../lib/env_manager.sh"
 
 # 初始化環境
 if ! env_init_for_script "aws_vpn_admin.sh"; then
@@ -25,11 +25,11 @@ CONFIG_FILE="$VPN_ENDPOINT_CONFIG_FILE"
 LOG_FILE="$VPN_ADMIN_LOG_FILE"
 
 # 載入核心函式庫
-source "$SCRIPT_DIR/lib/core_functions.sh"
-source "$SCRIPT_DIR/lib/aws_setup.sh"
-source "$SCRIPT_DIR/lib/cert_management.sh"
-source "$SCRIPT_DIR/lib/endpoint_creation.sh"
-source "$SCRIPT_DIR/lib/endpoint_management.sh"
+source "$SCRIPT_DIR/../lib/core_functions.sh"
+source "$SCRIPT_DIR/../lib/aws_setup.sh"
+source "$SCRIPT_DIR/../lib/cert_management.sh"
+source "$SCRIPT_DIR/../lib/endpoint_creation.sh"
+source "$SCRIPT_DIR/../lib/endpoint_management.sh"
 
 # 阻止腳本在出錯時繼續執行
 set -e
@@ -87,7 +87,7 @@ create_vpn_endpoint() {
     
     # 1. 生成證書 (如果不存在) - 使用環境感知路徑
     if [ ! -f "$VPN_CERT_DIR/pki/ca.crt" ]; then
-        generate_certificates_lib "$VPN_CERT_DIR"
+        generate_certificates_lib "$VPN_CERT_DIR" "$CONFIG_FILE"
         if [ $? -ne 0 ]; then
             echo -e "${RED}證書生成失敗。中止操作。${NC}"
             return 1
@@ -921,7 +921,7 @@ main() {
                 ;;
             E|e)
                 echo -e "\n${CYAN}=== 環境管理 ===${NC}"
-                "$SCRIPT_DIR/vpn_env.sh"
+                "$SCRIPT_DIR/../vpn_env.sh"
                 echo -e "\n${YELLOW}按任意鍵返回主選單...${NC}"
                 read -n 1
                 ;;

--- a/admin/revoke_member_access.sh
+++ b/admin/revoke_member_access.sh
@@ -8,7 +8,7 @@
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 
 # 載入環境管理器 (必須第一個載入)
-source "$SCRIPT_DIR/lib/env_manager.sh"
+source "$SCRIPT_DIR/../lib/env_manager.sh"
 
 # 初始化環境
 if ! env_init_for_script "revoke_member_access.sh"; then
@@ -26,8 +26,8 @@ CONFIG_FILE="$VPN_ENDPOINT_CONFIG_FILE"
 EASYRSA_DIR_REVOKE="$ENV_CERT_DIR/easy-rsa-env"
 
 # 載入核心函式庫
-source "$SCRIPT_DIR/lib/core_functions.sh"
-source "$SCRIPT_DIR/lib/cert_management.sh"
+source "$SCRIPT_DIR/../lib/core_functions.sh"
+source "$SCRIPT_DIR/../lib/cert_management.sh"
 
 # 阻止腳本在出錯時繼續執行
 set -e
@@ -403,7 +403,7 @@ revoke_certificates() {
                     echo -e "${BLUE}找到證書名稱: $cert_name${NC}"
                     
                     # 執行本地 easyrsa 撤銷
-                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$cert_name"; then
+                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$cert_name" "$CONFIG_FILE"; then
                         echo -e "${GREEN}✓ 本地撤銷成功: $cert_name${NC}"
                         easyrsa_revoked+=("$cert_name")
                     else
@@ -414,7 +414,7 @@ revoke_certificates() {
                     echo -e "${YELLOW}無法從證書標籤中獲取用戶名，嘗試使用參數用戶名: $username${NC}"
                     
                     # 使用腳本參數中的用戶名嘗試撤銷
-                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$username"; then
+                    if revoke_client_certificate_lib "$EASYRSA_DIR_REVOKE" "$username" "$CONFIG_FILE"; then
                         echo -e "${GREEN}✓ 本地撤銷成功 (使用用戶名): $username${NC}"
                         easyrsa_revoked+=("$username")
                     else

--- a/lib/aws_setup.sh
+++ b/lib/aws_setup.sh
@@ -94,7 +94,7 @@ EOF
         main_script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)" # SCRIPT_DIR of the script calling this lib function
         echo "EASYRSA_DIR=/usr/local/share/easy-rsa" >> "$main_config_file"
         # 使用環境變數而不是硬編碼路徑
-        echo "CERT_OUTPUT_DIR=${VPN_CERT_DIR:-$main_script_dir/certificates}" >> "$main_config_file"
+        update_config "$main_config_file" "CERT_OUTPUT_DIR" "$VPN_CERT_DIR"
         echo "SERVER_CERT_NAME_PREFIX=server" >> "$main_config_file"
         echo "CLIENT_CERT_NAME_PREFIX=client" >> "$main_config_file"
         log_message_core "AWS 配置已更新，區域: ${aws_region} 及其他預設配置。"

--- a/team_member_setup.sh
+++ b/team_member_setup.sh
@@ -394,8 +394,6 @@ generate_client_certificate() {
     # 優先檢查環境特定的 CA 證書路徑
     if [ -f "$VPN_CA_CERT_FILE" ]; then
         ca_cert_path="$VPN_CA_CERT_FILE"
-    elif [ -f "$SCRIPT_DIR/ca.crt" ]; then
-        ca_cert_path="$SCRIPT_DIR/ca.crt"
     elif [ -f "$VPN_CERT_DIR/ca.crt" ]; then
         ca_cert_path="$VPN_CERT_DIR/ca.crt"
     else


### PR DESCRIPTION
Moved aws_vpn_admin.sh and revoke_member_access.sh into a new admin/ subdirectory to improve project organization.

Updated internal path references within the moved scripts (for sourcing libraries from ../lib/ and calling other scripts like ../vpn_env.sh) to reflect their new location.