### PR TITLE
fix(monitoring): 修復憑證監控靜默死亡，並把 client 憑證納入監控範圍

### DIFF
--- a/admin-tools/monitoring/check_cert_expiry.sh
+++ b/admin-tools/monitoring/check_cert_expiry.sh
@@ -1,16 +1,25 @@
 #!/usr/bin/env bash
 # ====================================================================
-# VPN Server Certificate Expiry Monitor
+# VPN Certificate Expiry Monitor（server + client）
 # --------------------------------------------------------------------
-# 檢查 staging / production Client VPN 的 server 憑證到期日，接近到期時
-# 透過既有的 Slack webhook（存在 SSM /vpn/{env}/slack/webhook）發提醒。
+# 檢查 staging / production Client VPN 的憑證到期日，接近到期時透過既有的
+# Slack webhook（存在 SSM /vpn/{env}/slack/webhook）發提醒。監控兩類憑證：
+#   - server 憑證：ACM，ARN 取自 configs/{env}/vpn_endpoint.conf
+#   - client 憑證：本機 certs/{env}/users/*.crt（排除 ca.crt）
+#
+# 為什麼 client 憑證也要監控：它過期時 AWS VPN Client 只顯示「TLS handshake
+# error」，跟 server 憑證過期的畫面一模一樣，從 GUI 分不出根因。2026-06-27
+# 就是這樣無預警斷線的 —— 當時本監控只看 ACM，完全沒有告警。
 #
 # 設計為由 launchd 每天執行；平常靜默，只在下列情況發訊息：
-#   - 任一環境查詢失敗（全部失敗）→ 每天提醒（FAILURE，監控自身失明也要叫）
-#   - 任一環境 <= CRIT_DAYS         → 每天提醒（CRITICAL）
-#   - 任一環境 <= WARN_DAYS         → 每週一提醒（WARNING）
-#   - 有部分環境查詢失敗            → 每週一提醒（WARNING）
+#   - 所有 server 查詢都失敗        → 每天提醒（FAILURE，監控自身失明也要叫）
+#   - 任一憑證 <= CRIT_DAYS         → 每天提醒（CRITICAL）
+#   - 任一憑證 <= WARN_DAYS         → 每週一提醒（WARNING）
+#   - 有部分查詢失敗                → 每週一提醒（WARNING）
 #   - 每月 1 號                     → 心跳訊息（證明監控仍運作）
+#
+# 已過期的 client 憑證會持續觸發 CRITICAL，直到它被續期或（人員已離職時）
+# 從 certs/{env}/users/ 移除 —— 這是刻意的，過期憑證留在那裡本身就是問題。
 #
 # Webhook 在執行時才從 SSM 解密讀取，不寫死於檔案。
 # 無任何密鑰或硬編碼基礎設施 ID，可安全進版控。
@@ -28,6 +37,8 @@ REGION="${AWS_REGION:-us-east-1}"
 # 用哪個環境的 webhook 當通知管道（預設 staging，集中到同一個 channel）
 WEBHOOK_ENV="${WEBHOOK_ENV:-staging}"
 WEBHOOK_PROFILE="${WEBHOOK_PROFILE:-$WEBHOOK_ENV}"
+# SKIP_CLIENT_CERTS=1 可關閉 client 憑證檢查（例如手上沒有 certs/ 的機器）
+SKIP_CLIENT_CERTS="${SKIP_CLIENT_CERTS:-0}"
 
 # 要監控的環境： "環境名:AWS profile"（假設本機 AWS profile 名與環境名相同）
 # 可用環境變數 VPN_CERT_ENVS 覆寫（空白分隔），例：VPN_CERT_ENVS="staging:staging"
@@ -93,9 +104,36 @@ get_days_left() {
     echo "${days}|${notafter:0:19}"
 }
 
+# --- 讀取單一 client 憑證檔的剩餘天數，回傳 "days|enddate"，失敗回傳非 0 ---
+client_cert_days_left() {
+    local crt="$1"
+    local enddate norm exp_epoch now_epoch days
+    # openssl 輸出形如 "notAfter=Nov 19 02:21:12 2028 GMT"
+    enddate=$(openssl x509 -in "$crt" -noout -enddate 2>>"$LOG_FILE" | cut -d= -f2-)
+    [ -n "$enddate" ] || { log "[client] 讀不到 notAfter：$crt"; return 1; }
+
+    # 個位數日期會補成兩個空白（"Jun  5"），先壓成單一空白才餵得進 BSD date
+    norm=$(printf '%s' "$enddate" | tr -s ' ')
+    exp_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$norm" +%s 2>/dev/null)
+    [ -n "$exp_epoch" ] || { log "[client] 日期解析失敗：$crt（$enddate）"; return 1; }
+
+    now_epoch=$(date +%s)
+    # 向負無窮取整：未過期天數正確，已過期顯示負數（與 get_days_left 一致）
+    days=$(( (exp_epoch - now_epoch) / 86400 ))
+    [ $(( (exp_epoch - now_epoch) % 86400 )) -lt 0 ] && days=$(( days - 1 ))
+    echo "${days}|${norm}"
+}
+
 # --- 發送 Slack（從 SSM 讀 webhook）---
+# NO_SLACK=1：算出等級、照常寫 log，但不真的送出。安裝後的自我驗證用這個模式，
+# 因為它要驗的是「job 起不起得來」，不是「該不該叫人」——2026-08-17 就是少了它，
+# 從 worktree（沒有 configs/）跑驗證，誤發了一則 FAILURE 到團隊 channel。
 send_slack() {
     local text="$1" webhook
+    if [ "${NO_SLACK:-0}" = "1" ]; then
+        log "NO_SLACK=1，略過送出（訊息內容見上）"
+        return 0
+    fi
     webhook=$(aws ssm get-parameter --profile "$WEBHOOK_PROFILE" --region "$REGION" \
         --name "/vpn/$WEBHOOK_ENV/slack/webhook" --with-decryption \
         --query 'Parameter.Value' --output text 2>>"$LOG_FILE")
@@ -144,6 +182,44 @@ for entry in "${ENVIRONMENTS[@]}"; do
     [ "$days" -lt "$min_days" ] && min_days="$days"
 done
 
+# --- client 憑證：本機 certs/{env}/users/*.crt（排除 CA）---
+# 刻意獨立成第二個迴圈：上面的迴圈在 server 查詢失敗時會 continue，
+# 混在一起會讓「ACM 查不到」連帶把 client 憑證檢查也一起跳過。
+client_fail=0
+client_checked=0
+if [ "$SKIP_CLIENT_CERTS" = "1" ]; then
+    log "已略過 client 憑證檢查（SKIP_CLIENT_CERTS=1）"
+else
+    for entry in "${ENVIRONMENTS[@]}"; do
+        env="${entry%%:*}"
+        users_dir="$PROJECT_ROOT/certs/$env/users"
+        [ -d "$users_dir" ] || { log "[$env] 無 client 憑證目錄，略過：$users_dir"; continue; }
+        for crt in "$users_dir"/*.crt; do
+            [ -e "$crt" ] || break                                   # glob 未展開＝目錄內無 .crt
+            [ "$(basename "$crt")" = "ca.crt" ] && continue          # CA 不是 client 憑證
+            user="$(basename "$crt" .crt)"
+            if ! cresult=$(client_cert_days_left "$crt"); then
+                client_fail=$(( client_fail + 1 ))
+                status_lines+="• ${env}/${user} (client)：⚠️ 讀取失敗（見 log）"$'\n'
+                continue
+            fi
+            client_checked=$(( client_checked + 1 ))
+            cdays="${cresult%%|*}"; cend="${cresult##*|}"
+            log "[$env] client 憑證 ${user}：剩餘 ${cdays} 天（到期 ${cend}）"
+            cicon="✅"
+            [ "$cdays" -le "$WARN_DAYS" ] && cicon="🟠"
+            [ "$cdays" -le "$CRIT_DAYS" ] && cicon="🔴"
+            if [ "$cdays" -le 0 ]; then
+                status_lines+="• ${env}/${user} (client)：🔴 已過期 $(( -cdays )) 天（到期 ${cend}）"$'\n'
+            else
+                status_lines+="• ${env}/${user} (client)：${cicon} 剩 ${cdays} 天（到期 ${cend}）"$'\n'
+            fi
+            [ "$cdays" -lt "$min_days" ] && min_days="$cdays"
+        done
+    done
+    log "client 憑證檢查完成：${client_checked} 張，讀取失敗 ${client_fail} 張"
+fi
+
 weekday=$(date +%u)   # 1=Mon .. 7=Sun
 dom=$(date +%d)       # 01..31
 
@@ -155,8 +231,8 @@ elif [ "$min_days" -le "$CRIT_DAYS" ]; then
     level="CRITICAL"                                            # 緊急 → 每天
 elif [ "$min_days" -le "$WARN_DAYS" ] && [ "$weekday" = "1" ]; then
     level="WARNING"                                             # 接近到期 → 每週一
-elif [ "$fail_count" -gt 0 ] && [ "$weekday" = "1" ]; then
-    level="WARNING"                                             # 部分環境查詢失敗 → 每週一
+elif [ "$weekday" = "1" ] && { [ "$fail_count" -gt 0 ] || [ "$client_fail" -gt 0 ]; }; then
+    level="WARNING"                                             # 部分查詢失敗（server 或 client）→ 每週一
 elif [ "$dom" = "01" ]; then
     level="HEARTBEAT"                                           # 月初心跳
 fi
@@ -174,14 +250,15 @@ fi
 
 case "$level" in
     FAILURE)   header="🔴 *VPN 憑證監控查詢失敗*（無法確認到期狀態，請檢查 AWS 憑證/網路）" ;;
-    CRITICAL)  header="🔴 *VPN Server 憑證即將到期（緊急）*" ;;
-    WARNING)   header="🟠 *VPN Server 憑證到期提醒*" ;;
+    CRITICAL)  header="🔴 *VPN 憑證即將到期（緊急）*" ;;
+    WARNING)   header="🟠 *VPN 憑證到期提醒*" ;;
     HEARTBEAT) header="✅ *VPN 憑證監控月報*" ;;
 esac
 
 msg="${header}"$'\n'"${status_lines}"
 if [ "$level" = "CRITICAL" ] || [ "$level" = "WARNING" ]; then
-    msg+=$'\n'"續期方式：用現有 CA 重簽 → 匯入*新* ACM ARN → modify-client-vpn-endpoint（同 ARN reimport 無效）。詳見 memory: vpn-server-cert-renewal。"
+    msg+=$'\n'"server 憑證續期：用現有 CA 重簽 → 匯入*新* ACM ARN → modify-client-vpn-endpoint（同 ARN reimport 無效）。詳見 memory: vpn-server-cert-renewal。"
+    msg+=$'\n'"client 憑證續期：重新產 CSR → admin-tools/sign_csr.sh 簽 → 換掉 .ovpn 的 <cert>/<key>，server 端不用動。詳見 memory: vpn-client-cert-renewal。"
 fi
 
 log "等級=${level}，發送 Slack"

--- a/admin-tools/monitoring/check_cert_expiry.sh
+++ b/admin-tools/monitoring/check_cert_expiry.sh
@@ -54,7 +54,10 @@ fi
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOG_DIR="$PROJECT_ROOT/logs"
-mkdir -p "$LOG_DIR"
+# 建不出 log 目錄就必須大聲死掉：沒有 set -e，log() 會安靜地什麼都不寫，
+# 腳本照樣 exit 0 —— 那正是這支監控壞掉一個多月沒人發現的形狀。
+# 78 = EX_CONFIG，是 launchd 唯一會記下來的訊號。
+mkdir -p "$LOG_DIR" || { echo "無法建立 log 目錄：$LOG_DIR" >&2; exit 78; }
 LOG_FILE="$LOG_DIR/cert_monitor.log"
 
 log() { echo "$(date '+%Y-%m-%d %H:%M:%S') $*" >>"$LOG_FILE"; }
@@ -85,7 +88,9 @@ get_days_left() {
     local notafter
     notafter=$(aws acm describe-certificate --profile "$profile" --region "$REGION" \
         --certificate-arn "$arn" --query 'Certificate.NotAfter' --output text 2>>"$LOG_FILE")
-    [ -n "$notafter" ] && [ "$notafter" != "None" ] || { log "[$env] 無法取得 ACM NotAfter（profile=$profile）"; return 1; }
+    # ${} 必須加大括號：後面緊接全形「）」時，UTF-8 locale 下 bash 會把它的第一個
+    # byte 併進變數名，set -u 直接讓整個 subshell 爆掉，診斷訊息就永遠印不出來。
+    [ -n "$notafter" ] && [ "$notafter" != "None" ] || { log "[$env] 無法取得 ACM NotAfter（profile=${profile}）"; return 1; }
 
     # ACM CLI 回傳如 2028-09-24T18:52:45+08:00 或 ...Z；保留時區 offset 再解析
     local norm clean exp_epoch now_epoch days
@@ -115,7 +120,7 @@ client_cert_days_left() {
     # 個位數日期會補成兩個空白（"Jun  5"），先壓成單一空白才餵得進 BSD date
     norm=$(printf '%s' "$enddate" | tr -s ' ')
     exp_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$norm" +%s 2>/dev/null)
-    [ -n "$exp_epoch" ] || { log "[client] 日期解析失敗：$crt（$enddate）"; return 1; }
+    [ -n "$exp_epoch" ] || { log "[client] 日期解析失敗：${crt}（${enddate}）"; return 1; }
 
     now_epoch=$(date +%s)
     # 向負無窮取整：未過期天數正確，已過期顯示負數（與 get_days_left 一致）
@@ -193,9 +198,17 @@ else
     for entry in "${ENVIRONMENTS[@]}"; do
         env="${entry%%:*}"
         users_dir="$PROJECT_ROOT/certs/$env/users"
-        [ -d "$users_dir" ] || { log "[$env] 無 client 憑證目錄，略過：$users_dir"; continue; }
+        [ -d "$users_dir" ] || { log "[$env] 無 client 憑證目錄：${users_dir}"; continue; }
+        # nullglob：目錄裡沒有 .crt 時直接不進迴圈，不必用 [ -e ] 去猜 glob 有沒有展開。
+        # ⛔ 這裡以前是 `[ -e "$crt" ] || break` —— 一個斷掉的 symlink 會讓整個目錄
+        # 剩下的憑證全部不被檢查，而且沒有任何 log。過期憑證就是這樣被漏掉的形狀。
+        shopt -s nullglob
         for crt in "$users_dir"/*.crt; do
-            [ -e "$crt" ] || break                                   # glob 未展開＝目錄內無 .crt
+            if [ ! -e "$crt" ]; then                                 # 斷掉的 symlink / 剛被刪除
+                log "[$env] 憑證檔讀不到（斷掉的 symlink？）：${crt}"
+                client_fail=$(( client_fail + 1 ))
+                continue
+            fi
             [ "$(basename "$crt")" = "ca.crt" ] && continue          # CA 不是 client 憑證
             user="$(basename "$crt" .crt)"
             if ! cresult=$(client_cert_days_left "$crt"); then
@@ -216,8 +229,24 @@ else
             fi
             [ "$cdays" -lt "$min_days" ] && min_days="$cdays"
         done
+        shopt -u nullglob
     done
     log "client 憑證檢查完成：${client_checked} 張，讀取失敗 ${client_fail} 張"
+fi
+
+# 覆蓋數一定要進訊息本體：否則「檢查了 4 張都健康」與「一張都沒看到」
+# 送出的內容一模一樣，心跳訊息就證明不了任何事。
+if [ "$SKIP_CLIENT_CERTS" = "1" ]; then
+    status_lines+="• client 憑證：已略過（SKIP_CLIENT_CERTS=1）"$'\n'
+else
+    status_lines+="• client 憑證：已檢查 ${client_checked} 張（讀取失敗 ${client_fail} 張）"$'\n'
+fi
+
+# client 軸完全看不到東西 ＝ 失明，與「ACM 全部查不到」同級，每天叫。
+# 沒有這一條的話，certs/ 不存在只會留一行 log，而對外表現得跟健康完全一樣。
+client_blind=0
+if [ "$SKIP_CLIENT_CERTS" != "1" ] && [ "$client_checked" -eq 0 ]; then
+    client_blind=1
 fi
 
 weekday=$(date +%u)   # 1=Mon .. 7=Sun
@@ -226,7 +255,9 @@ dom=$(date +%d)       # 01..31
 # --- 決定提醒等級（fail-loud：全失敗最高優先，永不靜默吞掉失敗）---
 level=""
 if [ "$fail_count" -ge "$total" ]; then
-    level="FAILURE"                                              # 全部查詢失敗 → 每天叫
+    level="FAILURE"                                              # server 全部查詢失敗 → 每天叫
+elif [ "$client_blind" = "1" ]; then
+    level="FAILURE"                                              # client 軸一張都沒看到 → 每天叫
 elif [ "$min_days" -le "$CRIT_DAYS" ]; then
     level="CRITICAL"                                            # 緊急 → 每天
 elif [ "$min_days" -le "$WARN_DAYS" ] && [ "$weekday" = "1" ]; then

--- a/admin-tools/monitoring/check_cert_expiry.sh
+++ b/admin-tools/monitoring/check_cert_expiry.sh
@@ -282,7 +282,10 @@ elif [ "$client_blind" = "1" ]; then
     # 不是「查詢結果」訊號。放在前面會把「server 憑證剩 3 天」的告警標題改寫成
     # 「查詢失敗，請檢查 AWS 憑證/網路」—— 事實錯誤，而且會把 on-call 導向錯的
     # runbook。失明本身已經無條件寫進 status_lines，不會因為排在後面而消失。
-    level="FAILURE"                                             # 沒有其他等級時才由它升起 → 每天叫
+    # 用獨立的等級名而不是複用 FAILURE：兩者都每天叫，但成因完全不同 ——
+    # FAILURE 是「ACM 查不到」（去查 AWS profile / 網路），失明是「本機 certs/ 沒東西」。
+    # 共用 header 會叫 on-call 先去繞 AWS 一圈才發現是本機目錄的事。
+    level="CLIENT_BLIND"                                        # 沒有其他等級時才由它升起 → 每天叫
 elif [ "$dom" = "01" ]; then
     level="HEARTBEAT"                                           # 月初心跳
 fi
@@ -300,6 +303,7 @@ fi
 
 case "$level" in
     FAILURE)   header="🔴 *VPN 憑證監控查詢失敗*（無法確認到期狀態，請檢查 AWS 憑證/網路）" ;;
+    CLIENT_BLIND) header="🔴 *VPN client 憑證監控失明*（這台機器看不到任何 client 憑證，請確認 certs/<env>/users/ 存在且有非 ca.crt 的憑證；若這台本來就不該有，改用 SKIP_CLIENT_CERTS=1）" ;;
     CRITICAL)  header="🔴 *VPN 憑證即將到期（緊急）*" ;;
     WARNING)   header="🟠 *VPN 憑證到期提醒*" ;;
     HEARTBEAT) header="✅ *VPN 憑證監控月報*" ;;

--- a/admin-tools/monitoring/check_cert_expiry.sh
+++ b/admin-tools/monitoring/check_cert_expiry.sh
@@ -98,9 +98,12 @@ get_days_left() {
     norm="${notafter/%Z/+0000}"
     # 把 offset 的冒號去掉（BSD date %z 要 +0800 而非 +08:00）
     clean=$(printf '%s' "$norm" | sed -E 's/([+-][0-9]{2}):([0-9]{2})$/\1\2/')
-    exp_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S%z" "$clean" +%s 2>/dev/null)
+    # 這兩個格式全是數字、不含 %b，今天不受 locale 影響；仍然固定 LC_ALL=C，
+    # 這樣「所有日期解析都在 C locale」是一條可以一眼掃到的不變量，
+    # 而不是每次改格式都要重新推導一次會不會踩到 LC_TIME。
+    exp_epoch=$(LC_ALL=C date -j -f "%Y-%m-%dT%H:%M:%S%z" "$clean" +%s 2>/dev/null)
     # fallback：若無 offset 可解析，退回前 19 字以本地時區解析
-    [ -n "$exp_epoch" ] || exp_epoch=$(date -j -f "%Y-%m-%dT%H:%M:%S" "${notafter:0:19}" +%s 2>/dev/null)
+    [ -n "$exp_epoch" ] || exp_epoch=$(LC_ALL=C date -j -f "%Y-%m-%dT%H:%M:%S" "${notafter:0:19}" +%s 2>/dev/null)
     [ -n "$exp_epoch" ] || { log "[$env] 日期解析失敗: $notafter"; return 1; }
 
     now_epoch=$(date +%s)
@@ -120,7 +123,12 @@ client_cert_days_left() {
 
     # 個位數日期會補成兩個空白（"Jun  5"），先壓成單一空白才餵得進 BSD date
     norm=$(printf '%s' "$enddate" | tr -s ' ')
-    exp_epoch=$(date -j -f "%b %d %H:%M:%S %Y %Z" "$norm" +%s 2>/dev/null)
+    # 🔴 LC_ALL=C 是必要的，不是保險：openssl 的 -enddate 永遠輸出英文月份縮寫
+    # （Nov / Jun），但 BSD date 的 %b 吃 LC_TIME。在 zh_TW.UTF-8 / ja_JP.UTF-8 下
+    # 實測 rc=1「date: illegal time format」→ 每一張 client 憑證都被記成讀取失敗，
+    # 整條 client 軸失明。launchd 的環境剛好沒有 LANG 所以排程跑得動，但任何人從
+    # Terminal 手動驗證都會踩到 —— 那正是「看起來正常、其實什麼都沒檢查」的形狀。
+    exp_epoch=$(LC_ALL=C date -j -f "%b %d %H:%M:%S %Y %Z" "$norm" +%s 2>/dev/null)
     [ -n "$exp_epoch" ] || { log "[client] 日期解析失敗：${crt}（${enddate}）"; return 1; }
 
     now_epoch=$(date +%s)
@@ -256,10 +264,15 @@ dom=$(date +%d)       # 01..31
 
 # --- 決定提醒等級（fail-loud：全失敗最高優先，永不靜默吞掉失敗）---
 level=""
-if [ "$fail_count" -ge "$total" ]; then
+# ⛔ 「已知有東西快到期」必須排在「查詢失敗」之前。兩者都是每天叫，所以順序不影響
+# 叫不叫，只影響**標題**——而標題是 on-call 讀到的第一行。反過來排的話，
+# 「server ACM 查不到 ＋ client 憑證只剩 3 天」會被標成「🔴 查詢失敗，無法確認到期狀態，
+# 請檢查 AWS 憑證/網路」，那是事實錯誤（我們明明就確認了剩 3 天），還會把人導向錯的
+# runbook。查詢失敗本身不會消失：它在 status_lines 裡逐環境列出。
+if [ "$min_days" -le "$CRIT_DAYS" ]; then
+    level="CRITICAL"                                            # 已知緊急到期 → 每天
+elif [ "$fail_count" -ge "$total" ]; then
     level="FAILURE"                                              # server 全部查詢失敗 → 每天叫
-elif [ "$min_days" -le "$CRIT_DAYS" ]; then
-    level="CRITICAL"                                            # 緊急 → 每天
 elif [ "$min_days" -le "$WARN_DAYS" ] && [ "$weekday" = "1" ]; then
     level="WARNING"                                             # 接近到期 → 每週一
 elif [ "$weekday" = "1" ] && { [ "$fail_count" -gt 0 ] || [ "$client_fail" -gt 0 ]; }; then

--- a/admin-tools/monitoring/check_cert_expiry.sh
+++ b/admin-tools/monitoring/check_cert_expiry.sh
@@ -56,7 +56,8 @@ PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOG_DIR="$PROJECT_ROOT/logs"
 # 建不出 log 目錄就必須大聲死掉：沒有 set -e，log() 會安靜地什麼都不寫，
 # 腳本照樣 exit 0 —— 那正是這支監控壞掉一個多月沒人發現的形狀。
-# 78 = EX_CONFIG，是 launchd 唯一會記下來的訊號。
+# 用 78（EX_CONFIG）是為了對上本機歷史症狀、一眼認得出來 ——
+# 不是因為 launchd 只記得住 78，它任何 exit code 都會記在 last exit code。
 mkdir -p "$LOG_DIR" || { echo "無法建立 log 目錄：$LOG_DIR" >&2; exit 78; }
 LOG_FILE="$LOG_DIR/cert_monitor.log"
 
@@ -247,6 +248,7 @@ fi
 client_blind=0
 if [ "$SKIP_CLIENT_CERTS" != "1" ] && [ "$client_checked" -eq 0 ]; then
     client_blind=1
+    status_lines+="• ⚠️ client 憑證軸失明 —— 這台機器看不到任何 client 憑證"$'\n'
 fi
 
 weekday=$(date +%u)   # 1=Mon .. 7=Sun
@@ -256,14 +258,18 @@ dom=$(date +%d)       # 01..31
 level=""
 if [ "$fail_count" -ge "$total" ]; then
     level="FAILURE"                                              # server 全部查詢失敗 → 每天叫
-elif [ "$client_blind" = "1" ]; then
-    level="FAILURE"                                              # client 軸一張都沒看到 → 每天叫
 elif [ "$min_days" -le "$CRIT_DAYS" ]; then
     level="CRITICAL"                                            # 緊急 → 每天
 elif [ "$min_days" -le "$WARN_DAYS" ] && [ "$weekday" = "1" ]; then
     level="WARNING"                                             # 接近到期 → 每週一
 elif [ "$weekday" = "1" ] && { [ "$fail_count" -gt 0 ] || [ "$client_fail" -gt 0 ]; }; then
     level="WARNING"                                             # 部分查詢失敗（server 或 client）→ 每週一
+elif [ "$client_blind" = "1" ]; then
+    # ⛔ 這一條必須排在 CRITICAL/WARNING **之後**：client 軸失明是「覆蓋率」訊號，
+    # 不是「查詢結果」訊號。放在前面會把「server 憑證剩 3 天」的告警標題改寫成
+    # 「查詢失敗，請檢查 AWS 憑證/網路」—— 事實錯誤，而且會把 on-call 導向錯的
+    # runbook。失明本身已經無條件寫進 status_lines，不會因為排在後面而消失。
+    level="FAILURE"                                             # 沒有其他等級時才由它升起 → 每天叫
 elif [ "$dom" = "01" ]; then
     level="HEARTBEAT"                                           # 月初心跳
 fi
@@ -287,7 +293,10 @@ case "$level" in
 esac
 
 msg="${header}"$'\n'"${status_lines}"
-if [ "$level" = "CRITICAL" ] || [ "$level" = "WARNING" ]; then
+# 續期指示掛在「真的有憑證快到期」這個事實上，不是掛在 level 上。
+# 掛 level 的話，同一個「剩 3 天」在 FAILURE 標題下會拿不到 runbook —— 而那正是
+# on-call 最需要它的時候。
+if [ "$min_days" -le "$WARN_DAYS" ]; then
     msg+=$'\n'"server 憑證續期：用現有 CA 重簽 → 匯入*新* ACM ARN → modify-client-vpn-endpoint（同 ARN reimport 無效）。詳見 memory: vpn-server-cert-renewal。"
     msg+=$'\n'"client 憑證續期：重新產 CSR → admin-tools/sign_csr.sh 簽 → 換掉 .ovpn 的 <cert>/<key>，server 端不用動。詳見 memory: vpn-client-cert-renewal。"
 fi

--- a/admin-tools/monitoring/install_cert_monitor.sh
+++ b/admin-tools/monitoring/install_cert_monitor.sh
@@ -41,15 +41,37 @@ chmod +x "$CHECK_SCRIPT"
 
 # 從 git worktree 安裝會裝出一個沒有 configs/ 也沒有 certs/ 的監控（兩者都被
 # gitignore），每天都判成「查詢失敗」而狂發假警報，而且 worktree 一刪就整個斷掉。
-missing_conf=0
-for _e in staging production; do
-    [ -f "$PROJECT_ROOT/configs/$_e/vpn_endpoint.conf" ] || missing_conf=1
+# 檢查的環境要跟 check_cert_expiry.sh 一致：VPN_CERT_ENVS 有設就以它為準，
+# 否則才用預設的兩個。寫死 staging+production 會讓單一 profile 的機器裝不起來，
+# 而 VPN_CERT_ENVS 這個覆寫正是為那種機器存在的。
+if [ -n "${VPN_CERT_ENVS:-}" ]; then
+    # shellcheck disable=SC2206
+    _install_envs=($VPN_CERT_ENVS)
+else
+    _install_envs=("staging:staging" "production:production")
+fi
+
+missing_conf=""
+missing_certs=""
+for _entry in "${_install_envs[@]}"; do
+    _e="${_entry%%:*}"
+    [ -f "$PROJECT_ROOT/configs/$_e/vpn_endpoint.conf" ] || missing_conf="$missing_conf $_e"
+    [ -d "$PROJECT_ROOT/certs/$_e/users" ] || missing_certs="$missing_certs $_e"
 done
-if [ "$missing_conf" = "1" ]; then
-    echo "❌ 這個 checkout 缺少 configs/{staging,production}/vpn_endpoint.conf"
-    echo "   —— 看起來是從 git worktree 或全新 clone 安裝的。請改在正式的工作目錄執行："
-    echo "   $PROJECT_ROOT"
+
+if [ -n "$missing_conf" ]; then
+    echo "❌ 這個 checkout 缺少 configs/{$(echo "$missing_conf" | tr ' ' ',' | sed 's/^,//')}/vpn_endpoint.conf"
+    echo "   —— 看起來是從 git worktree 或全新 clone 安裝的（configs/ 與 certs/ 都被 gitignore）。"
+    echo "   從這裡安裝會每天發假警報，而且 worktree 一刪監控就整個斷掉。"
+    echo "   請改在正式的工作目錄執行： $PROJECT_ROOT"
     exit 1
+fi
+
+# certs/ 缺少只擋不住，但一定要講出來 —— 它的失效方向是「安靜地什麼都不檢查」。
+if [ -n "$missing_certs" ] && [ "${SKIP_CLIENT_CERTS:-0}" != "1" ]; then
+    echo "⚠️ 找不到 client 憑證目錄：${missing_certs}（certs/<env>/users）"
+    echo "   監控會照常安裝，但 client 憑證那一軸在這台機器上不會檢查到任何東西。"
+    echo "   若這台機器本來就不該有 certs/，請改用 SKIP_CLIENT_CERTS=1 安裝，讓意圖留下紀錄。"
 fi
 mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR" "$LAUNCHD_LOG_DIR"
 
@@ -57,19 +79,27 @@ mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR" "$LAUNCHD_LOG_DIR"
 # 會讓 job 起不來。改路徑後它們已無作用，順手清掉避免下次誤判。
 rm -f "$LOG_DIR/cert_monitor.launchd.out" "$LOG_DIR/cert_monitor.launchd.err"
 
-# $1=1 時額外塞 NO_SLACK=1（只給安裝後驗證那一次用，正式排程不帶）
+# --- plist 產生器 -----------------------------------------------------
+# 🔴 正式 plist 永遠不帶 NO_SLACK。驗證要用的「不發訊息」設定一律走下面的
+# 影子 job（獨立 label、獨立檔案、trap 保證移除），這樣任何失敗路徑
+# ——exit 1、逾時、Ctrl-C、set -e—— 都不可能留下一個註冊著、天天 exit 0、
+# 卻永遠不發告警的正式 job。那種狀態比沒有監控更糟：它會讓人以為有監控。
+# $1=plist 路徑 $2=label $3=no_slack(0|1) $4=stdout/stderr 檔名前綴
 write_plist() {
-    local no_slack_entry=""
-    if [ "${1:-0}" = "1" ]; then
-        no_slack_entry=$'        <key>NO_SLACK</key>\n        <string>1</string>\n'
-    fi
-    cat > "$PLIST" <<EOF
+    local plist_path="$1" label="$2" no_slack="$3" out_prefix="$4"
+    local extra_env=""
+    [ "$no_slack" = "1" ] && extra_env+=$'        <key>NO_SLACK</key>\n        <string>1</string>\n'
+    # 這兩個是 check_cert_expiry.sh 的設定開關；只在本機有設時才寫進 plist，
+    # 否則排程跑起來會忽略操作者在 shell 裡驗證過的設定（launchd 不繼承 shell 環境）。
+    [ -n "${SKIP_CLIENT_CERTS:-}" ] && extra_env+=$'        <key>SKIP_CLIENT_CERTS</key>\n        <string>'"${SKIP_CLIENT_CERTS}"$'</string>\n'
+    [ -n "${VPN_CERT_ENVS:-}" ] && extra_env+=$'        <key>VPN_CERT_ENVS</key>\n        <string>'"${VPN_CERT_ENVS}"$'</string>\n'
+    cat > "$plist_path" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
     <key>Label</key>
-    <string>$LABEL</string>
+    <string>$label</string>
     <key>ProgramArguments</key>
     <array>
         <string>/bin/bash</string>
@@ -79,7 +109,7 @@ write_plist() {
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-${no_slack_entry}    </dict>
+${extra_env}    </dict>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key><integer>10</integer>
@@ -88,35 +118,35 @@ ${no_slack_entry}    </dict>
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>$LAUNCHD_LOG_DIR/cert_monitor.launchd.out</string>
+    <string>${out_prefix}.out</string>
     <key>StandardErrorPath</key>
-    <string>$LAUNCHD_LOG_DIR/cert_monitor.launchd.err</string>
+    <string>${out_prefix}.err</string>
 </dict>
 </plist>
 EOF
 }
 
-reload_job() {
-    launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
-    launchctl bootstrap "$GUI" "$PLIST" 2>/dev/null || launchctl load -w "$PLIST" 2>/dev/null || {
-        echo "⚠️ launchctl 載入失敗（plist 已寫入 $PLIST），請手動檢查：launchctl bootstrap $GUI $PLIST"
-        exit 1
-    }
+# 只印安全欄位 —— launchctl print 會把整個 login session 的 inherited environment
+# 原樣吐出來（本機實際含有一個 ASANA PAT），不能叫人直接貼那份輸出去回報問題。
+SAFE_PRINT="launchctl print $GUI/$LABEL | grep -E 'state|last exit code|std(out|err) path'"
+
+# --- 第一段驗證：launchd 起得來嗎（用影子 job，絕不碰正式 plist）---------
+VERIFY_LABEL="${LABEL}.verify"
+VERIFY_PLIST="$LAUNCHD_LOG_DIR/${VERIFY_LABEL}.plist"
+cleanup_verify() {
+    launchctl bootout "$GUI/$VERIFY_LABEL" 2>/dev/null || true
+    rm -f "$VERIFY_PLIST"
 }
+trap cleanup_verify EXIT
 
-# 先用「不送 Slack」的版本註冊，跑一次驗證
-write_plist 1
-reload_job
-echo "📝 已產生 plist：$PLIST"
-
-echo "📅 排程已註冊（每天 10:00 執行）"
-
-# --- 安裝後自我驗證：真的跑一次，確認 job 起得來 -----------------------
-# 這一步存在的理由：上一版安裝「成功」了，但 job 從 2026-07-12 起每天都以
-# EX_CONFIG(78) 失敗、一個多月沒人發現。一個印 ✅ 卻沒驗證過的安裝腳本，
-# 本身就是無聲失效點 —— 監控壞掉的樣子跟「一切正常」長得一模一樣。
-echo "🔎 安裝後驗證：實際執行一次（NO_SLACK=1，不會發出任何訊息）..."
-launchctl kickstart -p "$GUI/$LABEL" >/dev/null 2>&1 || true
+echo "🔎 安裝前驗證：用一次性影子 job 實際跑一次（NO_SLACK=1，不會發出任何訊息）..."
+write_plist "$VERIFY_PLIST" "$VERIFY_LABEL" 1 "$LAUNCHD_LOG_DIR/verify"
+launchctl bootout "$GUI/$VERIFY_LABEL" 2>/dev/null || true
+if ! launchctl bootstrap "$GUI" "$VERIFY_PLIST" 2>&1; then
+    echo "❌ 影子 job 載入失敗 —— launchd 連這份設定都收不下，正式 plist 不會被安裝。"
+    exit 1
+fi
+launchctl kickstart -p "$GUI/$VERIFY_LABEL" >/dev/null 2>&1 || true
 
 # 等到 launchd 記下 last exit code 才算跑完。
 # ⛔ 不可改成「等 state 離開 running」：kickstart 是非同步的，job 還沒起來時
@@ -124,25 +154,50 @@ launchctl kickstart -p "$GUI/$LABEL" >/dev/null 2>&1 || true
 exit_code=""
 deadline=$(( $(date +%s) + 120 ))
 while [ "$(date +%s)" -lt "$deadline" ]; do
-    exit_code=$(launchctl print "$GUI/$LABEL" 2>/dev/null | sed -n 's/.*last exit code = \([0-9][0-9]*\).*/\1/p' | head -1) || true
+    exit_code=$(launchctl print "$GUI/$VERIFY_LABEL" 2>/dev/null | sed -n 's/.*last exit code = \([0-9][0-9]*\).*/\1/p' | head -1) || true
     [ -n "$exit_code" ] && break
     sleep 2
 done
 
-if [ "${exit_code:-}" = "0" ]; then
-    write_plist 0          # 驗證過了，換成正式設定（不帶 NO_SLACK）
-    reload_job
-    echo "✅ 驗證通過：job 實際執行完成且 exit 0；已切回正式設定"
-    echo "   查看狀態： launchctl print $GUI/$LABEL"
-    echo "   查看 log： tail -f $LOG_DIR/cert_monitor.log"
-else
-    echo "❌ 驗證失敗：last exit code = ${exit_code:-未知}（排程已註冊但跑不起來）"
+if [ "${exit_code:-}" != "0" ]; then
+    echo "❌ 驗證失敗：last exit code = ${exit_code:-未知（逾時，120 秒內沒跑完）}"
+    echo "   ⛔ 正式排程未安裝 —— 寧可沒有監控，也不要裝一個看起來活著卻不會叫的。"
     echo "   78 = EX_CONFIG，通常是 launchd 開不了 plist 指定的檔案路徑；"
     echo "   先確認 stdout/stderr 路徑不在 ~/Documents 等 TCC 保護目錄下。"
-    echo "   診斷： launchctl print $GUI/$LABEL"
-    echo "          ls -la@ $LAUNCHD_LOG_DIR"
+    if [ -s "$LAUNCHD_LOG_DIR/verify.err" ]; then
+        echo "   影子 job 的 stderr（保留在 $LAUNCHD_LOG_DIR/verify.err）："
+        sed 's/^/     | /' "$LAUNCHD_LOG_DIR/verify.err"
+    fi
+    echo "   診斷： ls -la@ ${LAUNCHD_LOG_DIR}"
     exit 1
 fi
+
+# 第二段驗證：exit 0 只證明「行程跑完了」，不證明它看得見任何東西。
+# NO_SLACK 之下即使全部查詢失敗也是 exit 0，所以再看它這一輪的實際產出。
+covered=$(grep -c '剩餘' "$LOG_DIR/cert_monitor.log" 2>/dev/null || echo 0)
+if [ "${covered:-0}" -eq 0 ]; then
+    echo "⚠️ 注意：這一輪沒有任何憑證被實際讀到（log 沒有『剩餘 N 天』）。"
+    echo "   job 起得來，但它可能什麼都看不到 —— 請檢查 $LOG_DIR/cert_monitor.log"
+fi
+
+cleanup_verify
+# 驗證成功才清掉影子 job 的 stdout/stderr；失敗時刻意留著當診斷線索。
+rm -f "$LAUNCHD_LOG_DIR/verify.out" "$LAUNCHD_LOG_DIR/verify.err"
+trap - EXIT
+
+# --- 驗證過了才安裝正式排程（永遠不帶 NO_SLACK）------------------------
+write_plist "$PLIST" "$LABEL" 0 "$LAUNCHD_LOG_DIR/cert_monitor.launchd"
+launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
+launchctl bootstrap "$GUI" "$PLIST" 2>/dev/null || launchctl load -w "$PLIST" 2>/dev/null || {
+    echo "⚠️ launchctl 載入失敗（plist 已寫入 ${PLIST}），請手動檢查：launchctl bootstrap $GUI $PLIST"
+    exit 1
+}
+grep -q 'NO_SLACK' "$PLIST" && { echo "❌ 內部錯誤：正式 plist 竟然含 NO_SLACK，已中止"; exit 1; }
+
+echo "📝 已產生 plist：$PLIST"
+echo "✅ 已驗證 launchd 可以啟動此設定並執行完成（exit 0），排程已安裝（每天 10:00）"
+echo "   查看狀態： $SAFE_PRINT"
+echo "   查看 log： tail -f $LOG_DIR/cert_monitor.log"
 
 if [ "${1:-}" = "--test" ]; then
     echo ""

--- a/admin-tools/monitoring/install_cert_monitor.sh
+++ b/admin-tools/monitoring/install_cert_monitor.sh
@@ -8,13 +8,22 @@
 # ====================================================================
 set -euo pipefail
 
-LABEL="com.newsleopard.vpn-cert-monitor"
+# 可用 VPN_CERT_MONITOR_LABEL 覆寫，讓安裝流程本身能在不動到正式 job 的前提下被測試
+LABEL="${VPN_CERT_MONITOR_LABEL:-com.newsleopard.vpn-cert-monitor}"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 CHECK_SCRIPT="$SCRIPT_DIR/check_cert_expiry.sh"
 PROJECT_ROOT="$(cd "$SCRIPT_DIR/../.." && pwd)"
 LOG_DIR="$PROJECT_ROOT/logs"
 PLIST="$HOME/Library/LaunchAgents/$LABEL.plist"
 GUI="gui/$(id -u)"
+
+# launchd 自己開的 stdout/stderr 一定要放在 ~/Documents 之外。
+# 原因（2026-08-17 實測）：~/Documents 底下的檔案會被系統蓋上 com.apple.macl
+# 這個檔案級 TCC ACL，只授權特定 app 存取。macOS 26.5.2 更新（2026-07-11）之後
+# launchd 不在授權名單內，開不了那兩個檔 → 每次啟動都以 EX_CONFIG(78) 失敗，
+# 腳本一行都沒跑，而且 stderr 也寫不出來 → 監控靜默死亡一個多月沒人發現。
+# ~/Library/Logs 不受 TCC 保護，不會有這個問題。
+LAUNCHD_LOG_DIR="$HOME/Library/Logs/newsleopard-vpn"
 
 uninstall() {
     launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
@@ -29,9 +38,32 @@ fi
 
 [ -f "$CHECK_SCRIPT" ] || { echo "❌ 找不到檢查腳本：$CHECK_SCRIPT"; exit 1; }
 chmod +x "$CHECK_SCRIPT"
-mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR"
 
-cat > "$PLIST" <<EOF
+# 從 git worktree 安裝會裝出一個沒有 configs/ 也沒有 certs/ 的監控（兩者都被
+# gitignore），每天都判成「查詢失敗」而狂發假警報，而且 worktree 一刪就整個斷掉。
+missing_conf=0
+for _e in staging production; do
+    [ -f "$PROJECT_ROOT/configs/$_e/vpn_endpoint.conf" ] || missing_conf=1
+done
+if [ "$missing_conf" = "1" ]; then
+    echo "❌ 這個 checkout 缺少 configs/{staging,production}/vpn_endpoint.conf"
+    echo "   —— 看起來是從 git worktree 或全新 clone 安裝的。請改在正式的工作目錄執行："
+    echo "   $PROJECT_ROOT"
+    exit 1
+fi
+mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR" "$LAUNCHD_LOG_DIR"
+
+# 舊版把 launchd 的 stdout/stderr 放在 $LOG_DIR，那兩個檔帶著 com.apple.macl
+# 會讓 job 起不來。改路徑後它們已無作用，順手清掉避免下次誤判。
+rm -f "$LOG_DIR/cert_monitor.launchd.out" "$LOG_DIR/cert_monitor.launchd.err"
+
+# $1=1 時額外塞 NO_SLACK=1（只給安裝後驗證那一次用，正式排程不帶）
+write_plist() {
+    local no_slack_entry=""
+    if [ "${1:-0}" = "1" ]; then
+        no_slack_entry=$'        <key>NO_SLACK</key>\n        <string>1</string>\n'
+    fi
+    cat > "$PLIST" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -47,7 +79,7 @@ cat > "$PLIST" <<EOF
     <dict>
         <key>PATH</key>
         <string>/opt/homebrew/bin:/usr/local/bin:/usr/bin:/bin:/usr/sbin:/sbin</string>
-    </dict>
+${no_slack_entry}    </dict>
     <key>StartCalendarInterval</key>
     <dict>
         <key>Hour</key><integer>10</integer>
@@ -56,25 +88,61 @@ cat > "$PLIST" <<EOF
     <key>RunAtLoad</key>
     <false/>
     <key>StandardOutPath</key>
-    <string>$LOG_DIR/cert_monitor.launchd.out</string>
+    <string>$LAUNCHD_LOG_DIR/cert_monitor.launchd.out</string>
     <key>StandardErrorPath</key>
-    <string>$LOG_DIR/cert_monitor.launchd.err</string>
+    <string>$LAUNCHD_LOG_DIR/cert_monitor.launchd.err</string>
 </dict>
 </plist>
 EOF
-
-echo "📝 已產生 plist：$PLIST"
-
-# 重新載入
-launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
-launchctl bootstrap "$GUI" "$PLIST" 2>/dev/null || launchctl load -w "$PLIST" 2>/dev/null || {
-    echo "⚠️ launchctl 載入失敗（plist 已寫入 $PLIST），請手動檢查：launchctl bootstrap $GUI $PLIST"
-    exit 1
 }
 
-echo "✅ 排程已安裝（每天 10:00 執行）"
-echo "   查看狀態： launchctl list | grep $LABEL"
-echo "   查看 log： tail -f $LOG_DIR/cert_monitor.log"
+reload_job() {
+    launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
+    launchctl bootstrap "$GUI" "$PLIST" 2>/dev/null || launchctl load -w "$PLIST" 2>/dev/null || {
+        echo "⚠️ launchctl 載入失敗（plist 已寫入 $PLIST），請手動檢查：launchctl bootstrap $GUI $PLIST"
+        exit 1
+    }
+}
+
+# 先用「不送 Slack」的版本註冊，跑一次驗證
+write_plist 1
+reload_job
+echo "📝 已產生 plist：$PLIST"
+
+echo "📅 排程已註冊（每天 10:00 執行）"
+
+# --- 安裝後自我驗證：真的跑一次，確認 job 起得來 -----------------------
+# 這一步存在的理由：上一版安裝「成功」了，但 job 從 2026-07-12 起每天都以
+# EX_CONFIG(78) 失敗、一個多月沒人發現。一個印 ✅ 卻沒驗證過的安裝腳本，
+# 本身就是無聲失效點 —— 監控壞掉的樣子跟「一切正常」長得一模一樣。
+echo "🔎 安裝後驗證：實際執行一次（NO_SLACK=1，不會發出任何訊息）..."
+launchctl kickstart -p "$GUI/$LABEL" >/dev/null 2>&1 || true
+
+# 等到 launchd 記下 last exit code 才算跑完。
+# ⛔ 不可改成「等 state 離開 running」：kickstart 是非同步的，job 還沒起來時
+# state 就已經不是 running，會在它開始之前就判定失敗（實測踩過）。
+exit_code=""
+deadline=$(( $(date +%s) + 120 ))
+while [ "$(date +%s)" -lt "$deadline" ]; do
+    exit_code=$(launchctl print "$GUI/$LABEL" 2>/dev/null | sed -n 's/.*last exit code = \([0-9][0-9]*\).*/\1/p' | head -1) || true
+    [ -n "$exit_code" ] && break
+    sleep 2
+done
+
+if [ "${exit_code:-}" = "0" ]; then
+    write_plist 0          # 驗證過了，換成正式設定（不帶 NO_SLACK）
+    reload_job
+    echo "✅ 驗證通過：job 實際執行完成且 exit 0；已切回正式設定"
+    echo "   查看狀態： launchctl print $GUI/$LABEL"
+    echo "   查看 log： tail -f $LOG_DIR/cert_monitor.log"
+else
+    echo "❌ 驗證失敗：last exit code = ${exit_code:-未知}（排程已註冊但跑不起來）"
+    echo "   78 = EX_CONFIG，通常是 launchd 開不了 plist 指定的檔案路徑；"
+    echo "   先確認 stdout/stderr 路徑不在 ~/Documents 等 TCC 保護目錄下。"
+    echo "   診斷： launchctl print $GUI/$LABEL"
+    echo "          ls -la@ $LAUNCHD_LOG_DIR"
+    exit 1
+fi
 
 if [ "${1:-}" = "--test" ]; then
     echo ""

--- a/admin-tools/monitoring/install_cert_monitor.sh
+++ b/admin-tools/monitoring/install_cert_monitor.sh
@@ -28,6 +28,10 @@ LAUNCHD_LOG_DIR="$HOME/Library/Logs/newsleopard-vpn"
 uninstall() {
     launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
     rm -f "$PLIST"
+    # 順手清掉驗證用的影子 job：正常情況下 trap 會清，但 SIGKILL／當機時不會，
+    # 殘留的影子會一直活到下次登入。
+    launchctl bootout "$GUI/${LABEL}.verify" 2>/dev/null || true
+    rm -f "$LAUNCHD_LOG_DIR/${LABEL}.verify.plist"
     echo "✅ 已移除排程與 plist：$PLIST"
 }
 
@@ -52,11 +56,17 @@ else
 fi
 
 missing_conf=""
-missing_certs=""
+client_cert_count=0
 for _entry in "${_install_envs[@]}"; do
     _e="${_entry%%:*}"
     [ -f "$PROJECT_ROOT/configs/$_e/vpn_endpoint.conf" ] || missing_conf="$missing_conf $_e"
-    [ -d "$PROJECT_ROOT/certs/$_e/users" ] || missing_certs="$missing_certs $_e"
+    # 數實際會被檢查到的憑證張數，不是「目錄在不在」——「目錄存在但裡面只有 ca.crt」
+    # 對監控來說跟目錄不存在完全一樣（都會判成失明），卻不會被目錄檢查抓到。
+    for _c in "$PROJECT_ROOT/certs/$_e/users"/*.crt; do
+        [ -e "$_c" ] || continue
+        [ "$(basename "$_c")" = "ca.crt" ] && continue
+        client_cert_count=$(( client_cert_count + 1 ))
+    done
 done
 
 if [ -n "$missing_conf" ]; then
@@ -67,10 +77,11 @@ if [ -n "$missing_conf" ]; then
     exit 1
 fi
 
-# certs/ 缺少只擋不住，但一定要講出來 —— 它的失效方向是「安靜地什麼都不檢查」。
-if [ -n "$missing_certs" ] && [ "${SKIP_CLIENT_CERTS:-0}" != "1" ]; then
-    echo "⚠️ 找不到 client 憑證目錄：${missing_certs}（certs/<env>/users）"
-    echo "   監控會照常安裝，但 client 憑證那一軸在這台機器上不會檢查到任何東西。"
+# 零張 client 憑證擋不住安裝，但一定要把後果講白 —— 監控會判成「失明」而每天叫。
+if [ "$client_cert_count" -eq 0 ] && [ "${SKIP_CLIENT_CERTS:-0}" != "1" ]; then
+    echo "⚠️ 這個 checkout 裡沒有任何 client 憑證（certs/<env>/users/*.crt，ca.crt 不算）"
+    echo "   監控會照常安裝，但 client 憑證那一軸看不到任何東西 → 判定為失明，"
+    echo "   從明天起【每天】會收到一則 🔴 FAILURE，直到補上憑證為止。"
     echo "   若這台機器本來就不該有 certs/，請改用 SKIP_CLIENT_CERTS=1 安裝，讓意圖留下紀錄。"
 fi
 mkdir -p "$HOME/Library/LaunchAgents" "$LOG_DIR" "$LAUNCHD_LOG_DIR"
@@ -87,12 +98,23 @@ rm -f "$LOG_DIR/cert_monitor.launchd.out" "$LOG_DIR/cert_monitor.launchd.err"
 # $1=plist 路徑 $2=label $3=no_slack(0|1) $4=stdout/stderr 檔名前綴
 write_plist() {
     local plist_path="$1" label="$2" no_slack="$3" out_prefix="$4"
-    local extra_env=""
-    [ "$no_slack" = "1" ] && extra_env+=$'        <key>NO_SLACK</key>\n        <string>1</string>\n'
-    # 這兩個是 check_cert_expiry.sh 的設定開關；只在本機有設時才寫進 plist，
-    # 否則排程跑起來會忽略操作者在 shell 裡驗證過的設定（launchd 不繼承 shell 環境）。
-    [ -n "${SKIP_CLIENT_CERTS:-}" ] && extra_env+=$'        <key>SKIP_CLIENT_CERTS</key>\n        <string>'"${SKIP_CLIENT_CERTS}"$'</string>\n'
-    [ -n "${VPN_CERT_ENVS:-}" ] && extra_env+=$'        <key>VPN_CERT_ENVS</key>\n        <string>'"${VPN_CERT_ENVS}"$'</string>\n'
+    local extra_env="" k v
+    if [ "$no_slack" = "1" ]; then
+        extra_env+=$'        <key>NO_SLACK</key>\n        <string>1</string>\n'
+    fi
+    # launchd 不繼承 shell 環境，所以 check_cert_expiry.sh 的每一個可覆寫參數都必須
+    # 明確寫進 plist，否則會出現最惡劣的那種落差：操作者用
+    # `WEBHOOK_ENV=production ./install_cert_monitor.sh --test` 看到訊息送進 production
+    # channel、認定設定生效，但排程隔天起全部送回預設值。要嘛全部帶，要嘛一個都別帶。
+    for k in WARN_DAYS CRIT_DAYS AWS_REGION WEBHOOK_ENV WEBHOOK_PROFILE \
+             SKIP_CLIENT_CERTS VPN_CERT_ENVS; do
+        eval "v=\${$k:-}"
+        [ -n "$v" ] || continue
+        # XML 逃脫：值裡有 & 或 < 會產生無效 plist（失效方向是大聲的 —— bootstrap
+        # 會失敗、exit 1 —— 但沒理由讓它發生）
+        v="${v//&/&amp;}"; v="${v//</&lt;}"; v="${v//>/&gt;}"
+        extra_env+="        <key>${k}</key>"$'\n'"        <string>${v}</string>"$'\n'
+    done
     cat > "$plist_path" <<EOF
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
@@ -146,6 +168,11 @@ if ! launchctl bootstrap "$GUI" "$VERIFY_PLIST" 2>&1; then
     echo "❌ 影子 job 載入失敗 —— launchd 連這份設定都收不下，正式 plist 不會被安裝。"
     exit 1
 fi
+# 先記下 log 目前的行數：底下的覆蓋率檢查只能看「這一輪新增的行」。
+# 掃整個歷史 log 的話，任何跑過一次的機器都會永遠通過這個檢查（no-op）。
+log_before=$(wc -l < "$LOG_DIR/cert_monitor.log" 2>/dev/null | tr -d ' ') || log_before=0
+[ -n "${log_before:-}" ] || log_before=0
+
 launchctl kickstart -p "$GUI/$VERIFY_LABEL" >/dev/null 2>&1 || true
 
 # 等到 launchd 記下 last exit code 才算跑完。
@@ -174,8 +201,12 @@ fi
 
 # 第二段驗證：exit 0 只證明「行程跑完了」，不證明它看得見任何東西。
 # NO_SLACK 之下即使全部查詢失敗也是 exit 0，所以再看它這一輪的實際產出。
-covered=$(grep -c '剩餘' "$LOG_DIR/cert_monitor.log" 2>/dev/null || echo 0)
-if [ "${covered:-0}" -eq 0 ]; then
+# ⚠️ `grep -c` 沒命中時會**同時**印 0 並 exit 1，所以寫成 `$(grep -c … || echo 0)`
+# 會得到 "0\n0"，`[ -eq ]` 直接語法錯誤 —— 也就是這個檢查在它唯一該觸發的那一格
+# 反而不會觸發。用 `|| true` 保留 grep 自己印的 0。
+covered=$(tail -n "+$(( log_before + 1 ))" "$LOG_DIR/cert_monitor.log" 2>/dev/null | grep -c '剩餘') || true
+[ -n "${covered:-}" ] || covered=0
+if [ "$covered" -eq 0 ]; then
     echo "⚠️ 注意：這一輪沒有任何憑證被實際讀到（log 沒有『剩餘 N 天』）。"
     echo "   job 起得來，但它可能什麼都看不到 —— 請檢查 $LOG_DIR/cert_monitor.log"
 fi
@@ -187,12 +218,22 @@ trap - EXIT
 
 # --- 驗證過了才安裝正式排程（永遠不帶 NO_SLACK）------------------------
 write_plist "$PLIST" "$LABEL" 0 "$LAUNCHD_LOG_DIR/cert_monitor.launchd"
+
+# ⛔ 斷言必須在 bootout/bootstrap **之前**：放在後面的話，真的觸發時那個含
+# NO_SLACK 的 job 已經上線，而 trap 也已經解掉，exit 1 不會清掉任何東西 ——
+# 剛好留下這整個 commit 想消滅的狀態。
+if grep -q 'NO_SLACK' "$PLIST"; then
+    echo "❌ 內部錯誤：正式 plist 竟然含 NO_SLACK，未安裝、已中止"
+    rm -f "$PLIST"
+    exit 1
+fi
+
 launchctl bootout "$GUI/$LABEL" 2>/dev/null || launchctl unload "$PLIST" 2>/dev/null || true
 launchctl bootstrap "$GUI" "$PLIST" 2>/dev/null || launchctl load -w "$PLIST" 2>/dev/null || {
-    echo "⚠️ launchctl 載入失敗（plist 已寫入 ${PLIST}），請手動檢查：launchctl bootstrap $GUI $PLIST"
+    echo "❌ launchctl 載入失敗 —— 舊的排程已經被移除，這台機器目前【完全沒有監控】。"
+    echo "   plist 已寫入 ${PLIST}，請手動執行：launchctl bootstrap $GUI $PLIST"
     exit 1
 }
-grep -q 'NO_SLACK' "$PLIST" && { echo "❌ 內部錯誤：正式 plist 竟然含 NO_SLACK，已中止"; exit 1; }
 
 echo "📝 已產生 plist：$PLIST"
 echo "✅ 已驗證 launchd 可以啟動此設定並執行完成（exit 0），排程已安裝（每天 10:00）"


### PR DESCRIPTION
Tier: 1 — 監控腳本改動，不涉及 auth/secrets、DB schema、破壞性基礎設施或跨服務契約
Pre-PR self-review: @critic ×2 (fix-delta); codex-verify: skipped (no trigger)

## 起因

2026-06-27 一位管理員的 VPN client 憑證過期，AWS VPN Client 只顯示
`Connection failed because of a TLS handshake error`。**沒有任何告警**，直到
2026-08-17 有人真的要連線才發現，中間 51 天無人知情。

事後查出**兩個獨立的洞**，這個 PR 各修一個。兩個洞的共同形狀是：
**壞掉的樣子跟「一切正常」長得一模一樣。**

## 洞 1 —— 監控自己從 2026-07-12 起就沒在跑

launchd job 每天都以 `EX_CONFIG(78)` 失敗，腳本一行都沒執行。

根因：plist 的 `StandardOut/ErrorPath` 指向 `~/Documents` 底下的檔案，那兩個檔
被系統蓋上 `com.apple.macl`（檔案級 TCC ACL，只授權特定 app）。macOS 26.5.2
（2026-07-11 安裝，就在最後一次成功執行的當天下午）之後 launchd 不在授權名單內
→ 開不了檔 → 整個 job 起不來，**連 stderr 都寫不出來**。

> 用三個 launchd 探針分離出是「既有檔案上的 macl」而非目錄層級的 TCC ——
> log→/tmp + `bash -c`、log→/tmp + 讀 `~/Documents` 的腳本、log→`~/Documents`
> 的**新**檔案，三者皆通過。第三個會通過，正是因為它建的是全新檔案。

**修法**
- plist 的 stdout/stderr 移到 `~/Library/Logs/newsleopard-vpn/`（不受 TCC 保護）
- **安裝後自我驗證**：用一次性影子 job 實際 kickstart 跑一次，確認 `exit 0`
  才安裝正式排程；失敗就完全不裝 —— 寧可沒有監控，也不要裝一個看起來活著卻不會叫的
- 擋下從 git worktree / 全新 clone 安裝（缺 `configs/` 會每天發假警報，
  而且 worktree 一刪監控就斷）。**這個 PR 的開發過程中就真的誤發過一則**
- 所有可覆寫參數寫進 plist（launchd 不繼承 shell 環境）

## 洞 2 —— 監控範圍只有 server 憑證

`check_cert_expiry.sh` 只查 ACM。但 client 憑證過期時，GUI 顯示的畫面跟 server
憑證過期**一模一樣**，從使用者端分不出根因（要看 OpenVPN log 的
`VERIFY OK: depth=0` 才能分辨）。

**修法**
- 新增 `certs/{env}/users/*.crt` 的到期檢查（排除 `ca.crt`），沿用同一組
  `WARN_DAYS`/`CRIT_DAYS` 門檻並計入 `min_days`
- 獨立成第二個迴圈：原迴圈在 ACM 查詢失敗時會 `continue`，混在一起會讓
  「ACM 查不到」連帶把 client 憑證檢查一起跳過
- **失明即告警**：`client_checked == 0` 且未明示 `SKIP_CLIENT_CERTS=1` → FAILURE
- 覆蓋張數無條件寫進訊息本體，讓心跳訊息能自證檢查了什麼

## 自審軌跡（兩輪 `@critic`，findings 全部修掉）

第一輪抓到三個 fail-open，第二輪抓到的兩個 Major **出在第一輪的修正本身** ——
都是「用來證明監控有在運作」的新機制自己 fail-open。逐條與修法見 commit message。

較值得一看的兩條：

- 驗證失敗會留下帶 `NO_SLACK=1` 的正式 plist → 之後每天照跑、log 照寫、`exit 0`，
  **但一則告警都不會發**。改成正式 plist 只寫一次且永不含 `NO_SLACK`，驗證改用
  trap 保證回收的影子 job。
- `covered=$(grep -c '剩餘' log || echo 0)` —— `grep -c` 沒命中時會**同時**印 0 並
  exit 1，`|| echo 0` 再補一個 → `"0\n0"` → `[ -eq ]` 語法錯誤。也就是這個檢查在
  它唯一該觸發的那一格反而不會觸發。而且它掃的是整個歷史 log 不是這一輪。

## 驗證

`bash -n` + `shellcheck -S warning` 全過（兩檔）。沙箱端到端測試：

| 情境 | 結果 |
|---|---|
| 憑證全健康 | 靜默、exit 0 |
| 塞入已過期 client 憑證 | 正確算出 **-51 天** → CRITICAL |
| 無 `certs/` 目錄 | FAILURE（**修正前是靜默** —— 就是這次的洞） |
| 斷掉的 symlink | 記錄並計為失敗，**其後的過期憑證仍被抓到**（修正前會 `break` 掉整個目錄） |
| client 失明 ＋ server 快到期 | CRITICAL 且保留續期 runbook（修正前是 FAILURE、runbook 消失） |
| 安裝驗證失敗 | 正式 plist／job／影子 job 皆不存在 |
| 安裝成功 | 正式 plist 不含 `NO_SLACK`，影子已清 |
| 覆蓋率檢查（預埋 3 行歷史「剩餘」） | 仍正確判定這一輪為 0，無 bash 錯誤 |

正式 job 目前已恢復運作（`last exit code = 0`），這個 PR 是防止再發生。

⚠️ **merge 後要在主 checkout 重跑一次 `./admin-tools/monitoring/install_cert_monitor.sh`**
才會套用新的 plist 內容（目前正式 job 是手動改路徑救回來的）。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01NGp4jtnDnkPJ6kbqv9fr3i
